### PR TITLE
Align governance tooling with v5.0 plan

### DIFF
--- a/docs/framework/1-governance/simple-span-framework-refinement-plan-v4.0.md
+++ b/docs/framework/1-governance/simple-span-framework-refinement-plan-v4.0.md
@@ -1,4 +1,3 @@
-
 ---
 title: SimpleSpan Framework Refinement Plan — v4.0 (Implementation Grade)
 version: 4.0
@@ -6,7 +5,10 @@ context: governance/refinement
 schema_version: 1
 last_reviewed: 2025-10-05
 ai_context: true
+status: archived
 ---
+
+> **Archived Plan:** This document is preserved for historical reference. Active governance and status tracking moved to `docs/framework/1-governance/simple-span-framework-refinement-plan-v5.0.md` under CCP `vCORE-5.0-ccp-baseline`.
 
 ## 🧭 YAML Resume Context
 
@@ -28,7 +30,7 @@ resume_context:
 
 ---
 
-# 📊 Project Progress Tracker
+# 📊 Project Progress Tracker *(Historical Snapshot)*
 
 | Phase | Description | % Done | Status | CCP Tag | Notes |
 |--------|--------------|--------|---------|----------|-------|

--- a/docs/framework/1-governance/simple-span-framework-refinement-plan-v5.0.md
+++ b/docs/framework/1-governance/simple-span-framework-refinement-plan-v5.0.md
@@ -104,10 +104,10 @@ Transition from v4.0 to AI-native governance. Establish continuity checkpoints a
 None (initial baseline).
 
 ### ✅ Checklist
-- [ ] Freeze v4.0 roadmap and record CCP tag (`vCORE-4.0-ccp-final`).
-- [ ] Add supersedes notice in v5.0 front-matter.
+- [x] Freeze v4.0 roadmap and record CCP tag (`vCORE-4.0-ccp-final`).
+- [x] Add supersedes notice in v5.0 front-matter.
 - [ ] Activate AIC orchestrator configuration (`tools/aic_orchestrator.config.yaml`).
-- [ ] Initialize `reports/progress.md` and `reports/ai/sessions/`.
+- [ ] Initialize `reports/progress.md` and `reports/ai/sessions/` (progress log active; sessions/ pending).
 - [ ] Log a baseline AIC session using `tools/ai/aic_logger.py`.
 
 ### 📄 Deliverables

--- a/docs/framework/ai/context-bootstrap.md
+++ b/docs/framework/ai/context-bootstrap.md
@@ -13,8 +13,8 @@ ai_context: true
 This document establishes the **official procedure** for rehydrating AI operational context within the SimpleSpan Framework.  
 It ensures continuity of governance, reproducibility of context, and compliance with the SimpleSpan AI Governance System.
 
-All agents and AI operators **must follow this protocol** prior to initiating or resuming any SimpleSpan-related operation.  
-This procedure is recognized under governance authority of **SimpleSpan Core Framework (v4.0)** and its **AIC Enablement & Automation Sub-Project**.
+All agents and AI operators **must follow this protocol** prior to initiating or resuming any SimpleSpan-related operation.
+This procedure is recognized under governance authority of **SimpleSpan Core Framework (v5.0)** and its **AIC Enablement & Automation Sub-Project**.
 
 ---
 
@@ -32,9 +32,9 @@ This protocol applies to all AI entities (AIC, Planner, Implementer, Reviewer, A
 ### Step 1 — Declare Context
 Begin every session by declaring:
 
-> "Load context from the SimpleSpan repository.  
-> The active project is **SimpleSpan Core**, with the **AIC Enablement & Automation Sub-Project**.  
-> Resume from Phase 1 — Governance & Policy Integration."
+> "Load context from the SimpleSpan repository.
+> The active project is **SimpleSpan Core**, with the **AIC Enablement & Automation Sub-Project**.
+> Resume from Phase 0 — Continuity & Genesis."
 
 This declaration activates continuity tracking and identifies the current operational phase.
 
@@ -43,8 +43,8 @@ This declaration activates continuity tracking and identifies the current operat
 ### Step 2 — Reference Core Governance Documents
 Load the following documents (in order) to establish base state:
 
-1. **Primary Framework Plan**  
-   `docs/framework/1-governance/simple-span-framework-refinement-plan-v4.0.md`
+1. **Primary Framework Plan**
+   `docs/framework/1-governance/simple-span-framework-refinement-plan-v5.0.md`
 
 2. **AIC Sub-Project Roadmap**  
    `docs/framework/ai/aic-subproject/roadmap.md`
@@ -123,9 +123,9 @@ All AI and human operators must adhere to these policies:
 ## 6. Appendix — Example Initialization Prompts
 
 ### (a) AIC Initialization Prompt
-> "Initialize AIC operations using the SimpleSpan Context Bootstrap Protocol.  
-> Load active governance and orchestration context.  
-> Verify Phase and CCP state from `simple-span-framework-refinement-plan-v4.0.md`.  
+> "Initialize AIC operations using the SimpleSpan Context Bootstrap Protocol.
+> Load active governance and orchestration context.
+> Verify Phase and CCP state from `simple-span-framework-refinement-plan-v5.0.md`.
 > Propose the next 1–3 actionable items under current phase checklist."
 
 ### (b) Planner Agent Prompt

--- a/tools/aic_orchestrator.py
+++ b/tools/aic_orchestrator.py
@@ -3,7 +3,7 @@
 """
 AIC Orchestrator (read-only v1)
 --------------------------------
-Reads the v4.0 plan and progress log, loads YAML resume_context, identifies the
+Reads the v5.0 plan and progress log, loads YAML resume_context, identifies the
 current phase, and prints the next 1–3 unchecked checklist items with helpful
 hints. Uses only the Python stdlib.
 
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Tuple, Dict
 
-DEFAULT_PLAN = "docs/framework/1-governance/simple-span-framework-refinement-plan-v4.0.md"
+DEFAULT_PLAN = "docs/framework/1-governance/simple-span-framework-refinement-plan-v5.0.md"
 DEFAULT_PROGRESS = "reports/progress.md"
 
 ALLOWLIST_PATHS = [
@@ -31,18 +31,14 @@ ALLOWLIST_PATHS = [
 DIFF_CAPS = {"files": 12, "lines": 600}
 
 PHASE_TITLES = {
-    0: "Repository Synchronization & Baseline",
-    1: "Governance Review & Consolidation",
-    2: "Schema & Goal Tag Implementation",
-    3: "Governance Audit & Cross-Reference",
-    4: "Automation Track 1",
-    5: "Agent Pipeline",
-    6: "FEA Domain Initialization",
-    7: "Governance Scanner & Auto-Tasks",
-    8: "Autonomous Validation & Release",
-    9: "Continuous Learning Factory",
-    10: "Multi-Domain Expansion",
-    11: "Continuity & Context Preservation",
+    0: "Continuity & Genesis",
+    1: "AI Governance Integration",
+    2: "Validation & Logging Automation",
+    3: "Modular Intelligence Integration",
+    4: "Human-AI Collaboration Protocols",
+    5: "Telemetry & Reporting Framework",
+    6: "Expansion & Domain Scaling",
+    7: "CCP Audit & Lifecycle Mgmt",
 }
 
 @dataclass


### PR DESCRIPTION
## Summary
- point the AIC orchestrator and AI context bootstrap protocol at the v5.0 framework plan and refresh the phase titles
- migrate phase 0 status indicators into the v5.0 checklist while archiving the v4.0 roadmap in-place for historical reference
- harden docs_audit to run without PyYAML and fix the --check-ai-logs flag handling

## Testing
- python tools/docs_audit.py --strict *(fails: existing documentation missing required front-matter metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68e29e84fe848324b431c07697f3c32c